### PR TITLE
Use RenderObject system.

### DIFF
--- a/DebugRendering/DebugRenderFeature.cs
+++ b/DebugRendering/DebugRenderFeature.cs
@@ -16,12 +16,155 @@ namespace DebugRendering
     public class DebugRenderFeature : RootRenderFeature
     {
 
-        internal class DummyDebugRenderObject : RenderObject
+        public class DebugRenderObject : RenderObject
         {
+
+            /* messages */
+            internal readonly FastList<Renderable> renderablesWithDepth = new FastList<Renderable>();
+            internal readonly FastList<Renderable> renderablesNoDepth = new FastList<Renderable>();
+
+            /* accumulators used when data is being pushed to the system */
+            internal Primitives totalPrimitives, totalPrimitivesNoDepth;
+
+            /* state set from outside */
+            internal FillMode currentFillMode = FillMode.Wireframe;
+
+            public void SetFillMode(FillMode fillMode)
+            {
+                currentFillMode = fillMode;
+            }
+
+            public void DrawQuad(ref Vector3 position, ref Vector2 size, ref Quaternion rotation, ref Color color, bool depthTest = true)
+            {
+                var cmd = new Quad() { Position = position, Size = size, Rotation = rotation, Color = color };
+                var msg = new Renderable(ref cmd);
+                if (depthTest)
+                {
+                    renderablesWithDepth.Add(msg);
+                    totalPrimitives.Quads++;
+                }
+                else
+                {
+                    renderablesNoDepth.Add(msg);
+                    totalPrimitivesNoDepth.Quads++;
+                }
+            }
+
+            public void DrawCircle(ref Vector3 position, float radius, ref Quaternion rotation, ref Color color, bool depthTest = true)
+            {
+                var cmd = new Circle() { Position = position, Radius = radius, Rotation = rotation, Color = color };
+                var msg = new Renderable(ref cmd);
+                if (depthTest)
+                {
+                    renderablesWithDepth.Add(msg);
+                    totalPrimitives.Circles++;
+                }
+                else
+                {
+                    renderablesNoDepth.Add(msg);
+                    totalPrimitivesNoDepth.Circles++;
+                }
+            }
+
+            public void DrawSphere(ref Vector3 position, float radius, ref Color color, bool depthTest = true)
+            {
+                var cmd = new Sphere() { Position = position, Radius = radius, Color = color };
+                var msg = new Renderable(ref cmd);
+                if (depthTest)
+                {
+                    renderablesWithDepth.Add(msg);
+                    totalPrimitives.Spheres++;
+                }
+                else
+                {
+                    renderablesNoDepth.Add(msg);
+                    totalPrimitivesNoDepth.Spheres++;
+                }
+            }
+
+            public void DrawCube(ref Vector3 start, ref Vector3 end, ref Quaternion rotation, ref Color color, bool depthTest = true)
+            {
+                var cmd = new Cube() { Start = start, End = end, Rotation = rotation, Color = color };
+                var msg = new Renderable(ref cmd);
+                if (depthTest)
+                {
+                    renderablesWithDepth.Add(msg);
+                    totalPrimitives.Cubes++;
+                }
+                else
+                {
+                    renderablesNoDepth.Add(msg);
+                    totalPrimitivesNoDepth.Cubes++;
+                }
+            }
+
+            public void DrawCapsule(ref Vector3 position, float height, float radius, ref Quaternion rotation, ref Color color, bool depthTest = true)
+            {
+                var cmd = new Capsule() { Position = position, Height = height, Radius = radius, Rotation = rotation, Color = color };
+                var msg = new Renderable(ref cmd);
+                if (depthTest)
+                {
+                    renderablesWithDepth.Add(msg);
+                    totalPrimitives.Capsules++;
+                }
+                else
+                {
+                    renderablesNoDepth.Add(msg);
+                    totalPrimitivesNoDepth.Capsules++;
+                }
+            }
+
+            public void DrawCylinder(ref Vector3 position, float height, float radius, ref Quaternion rotation, ref Color color, bool depthTest = true)
+            {
+                var cmd = new Cylinder() { Position = position, Height = height, Radius = radius, Rotation = rotation, Color = color };
+                var msg = new Renderable(ref cmd);
+                if (depthTest)
+                {
+                    renderablesWithDepth.Add(msg);
+                    totalPrimitives.Cylinders++;
+                }
+                else
+                {
+                    renderablesNoDepth.Add(msg);
+                    totalPrimitivesNoDepth.Cylinders++;
+                }
+            }
+
+            public void DrawCone(ref Vector3 position, float height, float radius, ref Quaternion rotation, ref Color color, bool depthTest = true)
+            {
+                var cmd = new Cone() { Position = position, Height = height, Radius = radius, Rotation = rotation, Color = color };
+                var msg = new Renderable(ref cmd);
+                if (depthTest)
+                {
+                    renderablesWithDepth.Add(msg);
+                    totalPrimitives.Cones++;
+                }
+                else
+                {
+                    renderablesNoDepth.Add(msg);
+                    totalPrimitivesNoDepth.Cones++;
+                }
+            }
+
+            public void DrawLine(ref Vector3 start, ref Vector3 end, ref Color color, bool depthTest = true)
+            {
+                var cmd = new Line() { Start = start, End = end, Color = color };
+                var msg = new Renderable(ref cmd);
+                if (depthTest)
+                {
+                    renderablesWithDepth.Add(msg);
+                    totalPrimitives.Lines++;
+                }
+                else
+                {
+                    renderablesNoDepth.Add(msg);
+                    totalPrimitivesNoDepth.Lines++;
+                }
+            }
 
         }
 
-        public override Type SupportedRenderObjectType => typeof(DummyDebugRenderObject);
+        public override Type SupportedRenderObjectType => typeof(DebugRenderObject);
 
         internal struct Primitives
         {
@@ -270,13 +413,6 @@ namespace DebugRendering
         private EffectInstance lineEffect;
         private Buffer transformBuffer;
         private Buffer colorBuffer;
-
-        /* messages */
-        private readonly FastList<Renderable> renderablesWithDepth = new FastList<Renderable>();
-        private readonly FastList<Renderable> renderablesNoDepth = new FastList<Renderable>();
-
-        /* accumulators used when data is being pushed to the system */
-        private Primitives totalPrimitives, totalPrimitivesNoDepth;
         
         /* used to specify offset into instance data buffers when drawing */
         private Primitives instanceOffsets, instanceOffsetsNoDepth;
@@ -294,147 +430,12 @@ namespace DebugRendering
         /* data only for line rendering */
         private readonly FastList<LineVertex> lineVertices = new FastList<LineVertex>(1);
 
-        /* state set from outside */
-        private FillMode currentFillMode = FillMode.Wireframe;
 
         /* where do we render? */
         public RenderGroupMask RenderGroup { get; set; } = RenderGroupMask.All;
 
         public DebugRenderFeature()
         {
-        }
-
-        public void SetFillMode(FillMode fillMode)
-        {
-            currentFillMode = fillMode;
-        }
-
-        public void DrawQuad(ref Vector3 position, ref Vector2 size, ref Quaternion rotation, ref Color color, bool depthTest = true)
-        {
-            var cmd = new Quad() { Position = position, Size = size, Rotation = rotation, Color = color };
-            var msg = new Renderable(ref cmd);
-            if (depthTest)
-            {
-                renderablesWithDepth.Add(msg);
-                totalPrimitives.Quads++;
-            }
-            else
-            {
-                renderablesNoDepth.Add(msg);
-                totalPrimitivesNoDepth.Quads++;
-            }
-        }
-
-        public void DrawCircle(ref Vector3 position, float radius, ref Quaternion rotation, ref Color color, bool depthTest = true)
-        {
-            var cmd = new Circle() { Position = position, Radius = radius, Rotation = rotation, Color = color };
-            var msg = new Renderable(ref cmd);
-            if (depthTest)
-            {
-                renderablesWithDepth.Add(msg);
-                totalPrimitives.Circles++;
-            }
-            else
-            {
-                renderablesNoDepth.Add(msg);
-                totalPrimitivesNoDepth.Circles++;
-            }
-        }
-
-        public void DrawSphere(ref Vector3 position, float radius, ref Color color, bool depthTest = true)
-        {
-            var cmd = new Sphere() { Position = position, Radius = radius, Color = color };
-            var msg = new Renderable(ref cmd);
-            if (depthTest)
-            {
-                renderablesWithDepth.Add(msg);
-                totalPrimitives.Spheres++;
-            }
-            else
-            {
-                renderablesNoDepth.Add(msg);
-                totalPrimitivesNoDepth.Spheres++;
-            }
-        }
-
-        public void DrawCube(ref Vector3 start, ref Vector3 end, ref Quaternion rotation, ref Color color, bool depthTest = true)
-        {
-            var cmd = new Cube() { Start = start, End = end, Rotation = rotation, Color = color };
-            var msg = new Renderable(ref cmd);
-            if (depthTest)
-            {
-                renderablesWithDepth.Add(msg);
-                totalPrimitives.Cubes++;
-            }
-            else
-            {
-                renderablesNoDepth.Add(msg);
-                totalPrimitivesNoDepth.Cubes++;
-            }
-        }
-
-        public void DrawCapsule(ref Vector3 position, float height, float radius, ref Quaternion rotation, ref Color color, bool depthTest = true)
-        {
-            var cmd = new Capsule() { Position = position, Height = height, Radius = radius, Rotation = rotation, Color = color };
-            var msg = new Renderable(ref cmd);
-            if (depthTest)
-            {
-                renderablesWithDepth.Add(msg);
-                totalPrimitives.Capsules++;
-            }
-            else
-            {
-                renderablesNoDepth.Add(msg);
-                totalPrimitivesNoDepth.Capsules++;
-            }
-        }
-
-        public void DrawCylinder(ref Vector3 position, float height, float radius, ref Quaternion rotation, ref Color color, bool depthTest = true)
-        {
-            var cmd = new Cylinder() { Position = position, Height = height, Radius = radius, Rotation = rotation, Color = color };
-            var msg = new Renderable(ref cmd);
-            if (depthTest)
-            {
-                renderablesWithDepth.Add(msg);
-                totalPrimitives.Cylinders++;
-            }
-            else
-            {
-                renderablesNoDepth.Add(msg);
-                totalPrimitivesNoDepth.Cylinders++;
-            }
-        }
-
-        public void DrawCone(ref Vector3 position, float height, float radius, ref Quaternion rotation, ref Color color, bool depthTest = true)
-        {
-            var cmd = new Cone() { Position = position, Height = height, Radius = radius, Rotation = rotation, Color = color };
-            var msg = new Renderable(ref cmd);
-            if (depthTest)
-            {
-                renderablesWithDepth.Add(msg);
-                totalPrimitives.Cones++;
-            }
-            else
-            {
-                renderablesNoDepth.Add(msg);
-                totalPrimitivesNoDepth.Cones++;
-            }
-        }
-
-        public void DrawLine(ref Vector3 start, ref Vector3 end, ref Color color, bool depthTest = true)
-        {
-            var cmd = new Line() { Start = start, End = end, Color = color };
-            var msg = new Renderable(ref cmd);
-            if (depthTest)
-            {
-                renderablesWithDepth.Add(msg);
-                totalPrimitives.Lines++;
-            }
-            else
-            {
-                renderablesNoDepth.Add(msg);
-                totalPrimitivesNoDepth.Lines++;
-            }
         }
 
         protected override void InitializeCore()
@@ -656,36 +657,42 @@ namespace DebugRendering
                 return offsets;
             }
 
+            // TODO: check if we actually have an object first next here
+
+            if (ObjectNodeReferences.Count <= 0) return;
+            ObjectNode objectNode = GetObjectNode(ObjectNodeReferences[0]);
+            DebugRenderObject debugObject = (DebugRenderObject)objectNode.RenderObject;
+
             /* everything except lines is included here, as lines just get accumulated into a buffer directly */
-            int primitivesWithDepth = SumBasicPrimitives(ref totalPrimitives);
-            int primitivesWithoutDepth = SumBasicPrimitives(ref totalPrimitivesNoDepth);
+            int primitivesWithDepth = SumBasicPrimitives(ref debugObject.totalPrimitives);
+            int primitivesWithoutDepth = SumBasicPrimitives(ref debugObject.totalPrimitivesNoDepth);
             int totalThingsToDraw = primitivesWithDepth + primitivesWithoutDepth;
 
             instances.Resize(totalThingsToDraw, true);
 
-            lineVertices.Resize((totalPrimitives.Lines * 2) + (totalPrimitivesNoDepth.Lines * 2), true);
+            lineVertices.Resize((debugObject.totalPrimitives.Lines * 2) + (debugObject.totalPrimitivesNoDepth.Lines * 2), true);
 
-            var primitiveOffsets = SetupPrimitiveOffsets(ref totalPrimitives);
-            var primitiveOffsetsNoDepth = SetupPrimitiveOffsets(ref totalPrimitivesNoDepth, primitivesWithDepth);
+            var primitiveOffsets = SetupPrimitiveOffsets(ref debugObject.totalPrimitives);
+            var primitiveOffsetsNoDepth = SetupPrimitiveOffsets(ref debugObject.totalPrimitivesNoDepth, primitivesWithDepth);
 
             /* line rendering data, separate buffer so offset isnt relative to the other data */
             primitiveOffsets.Lines = 0;
-            primitiveOffsetsNoDepth.Lines = totalPrimitives.Lines * 2;
+            primitiveOffsetsNoDepth.Lines = debugObject.totalPrimitives.Lines * 2;
 
             /* save instance offsets before we mutate them as we need them when rendering */
             instanceOffsets = primitiveOffsets;
             instanceOffsetsNoDepth = primitiveOffsetsNoDepth;
 
-            ProcessRenderables(renderablesWithDepth, ref primitiveOffsets);
-            ProcessRenderables(renderablesNoDepth, ref primitiveOffsetsNoDepth);
+            ProcessRenderables(debugObject.renderablesWithDepth, ref primitiveOffsets);
+            ProcessRenderables(debugObject.renderablesNoDepth, ref primitiveOffsetsNoDepth);
 
-            primitivesToDraw = totalPrimitives;
-            primitivesToDrawNoDepth = totalPrimitivesNoDepth;
+            primitivesToDraw = debugObject.totalPrimitives;
+            primitivesToDrawNoDepth = debugObject.totalPrimitivesNoDepth;
 
-            renderablesWithDepth.Clear(true);
-            renderablesNoDepth.Clear(true);
-            totalPrimitives.Clear();
-            totalPrimitivesNoDepth.Clear();
+            debugObject.renderablesWithDepth.Clear(true);
+            debugObject.renderablesNoDepth.Clear(true);
+            debugObject.totalPrimitives.Clear();
+            debugObject.totalPrimitivesNoDepth.Clear();
 
         }
 
@@ -808,7 +815,7 @@ namespace DebugRendering
             commandList.SetPipelineState(pipelineState.CurrentState);
 
             // we set line width to something absurdly high to avoid having to alter our shader substantially for now
-            primitiveEffect.Parameters.Set(PrimitiveShaderKeys.LineWidthMultiplier, (currentFillMode == FillMode.Solid) ? 10000.0f : 1.0f);
+            primitiveEffect.Parameters.Set(PrimitiveShaderKeys.LineWidthMultiplier, (fillMode == FillMode.Solid) ? 10000.0f : 1.0f);
             primitiveEffect.Parameters.Set(PrimitiveShaderKeys.ViewProjection, renderView.ViewProjection);
             primitiveEffect.Parameters.Set(PrimitiveShaderKeys.Transforms, transformBuffer);
             primitiveEffect.Parameters.Set(PrimitiveShaderKeys.Colors, colorBuffer);
@@ -820,7 +827,7 @@ namespace DebugRendering
             if (counts.Spheres > 0)
             {
 
-                SetPrimitiveRenderingPipelineState(commandList, depthTest, currentFillMode, isDoubleSided: false);
+                SetPrimitiveRenderingPipelineState(commandList, depthTest, fillMode, isDoubleSided: false);
                 commandList.SetPipelineState(pipelineState.CurrentState);
 
                 primitiveEffect.Parameters.Set(PrimitiveShaderKeys.InstanceOffset, offsets.Spheres);
@@ -833,7 +840,7 @@ namespace DebugRendering
             if (counts.Quads > 0 || counts.Circles > 0)
             {
 
-                SetPrimitiveRenderingPipelineState(commandList, depthTest, currentFillMode, isDoubleSided: true);
+                SetPrimitiveRenderingPipelineState(commandList, depthTest, fillMode, isDoubleSided: true);
                 commandList.SetPipelineState(pipelineState.CurrentState);
 
                 // draw quads
@@ -863,7 +870,7 @@ namespace DebugRendering
             if (counts.Cubes > 0 || counts.Capsules > 0 || counts.Cylinders > 0 || counts.Cones > 0)
             {
 
-                SetPrimitiveRenderingPipelineState(commandList, depthTest, currentFillMode, isDoubleSided: false);
+                SetPrimitiveRenderingPipelineState(commandList, depthTest, fillMode, isDoubleSided: false);
                 commandList.SetPipelineState(pipelineState.CurrentState);
 
                 // draw cubes
@@ -933,6 +940,11 @@ namespace DebugRendering
         public override void Draw(RenderDrawContext context, RenderView renderView, RenderViewStage renderViewStage)
         {
 
+            // TODO: check if we actually have one first next
+            if (ObjectNodeReferences.Count <= 0) return;
+            ObjectNode objectNode = GetObjectNode(ObjectNodeReferences[0]);
+            DebugRenderObject debugObject = (DebugRenderObject)objectNode.RenderObject;
+
             RenderStage FindTransparentRenderStage(RenderSystem renderSystem)
             {
                 for (int i = 0; i < renderSystem.RenderStages.Count; ++i)
@@ -959,12 +971,12 @@ namespace DebugRendering
             var commandList = context.CommandList;
 
             // update pipeline state, render with depth test first
-            SetPrimitiveRenderingPipelineState(commandList, depthTest: true, selectedFillMode: currentFillMode);
-            RenderPrimitives(context, renderView, ref instanceOffsets, ref primitivesToDraw, depthTest: true, fillMode: currentFillMode);
+            SetPrimitiveRenderingPipelineState(commandList, depthTest: true, selectedFillMode: debugObject.currentFillMode);
+            RenderPrimitives(context, renderView, ref instanceOffsets, ref primitivesToDraw, depthTest: true, fillMode: debugObject.currentFillMode);
 
             // render without depth test second
-            SetPrimitiveRenderingPipelineState(commandList, depthTest: false, selectedFillMode: currentFillMode);
-            RenderPrimitives(context, renderView, offsets: ref instanceOffsetsNoDepth, counts: ref primitivesToDrawNoDepth, depthTest: false, fillMode: currentFillMode);
+            SetPrimitiveRenderingPipelineState(commandList, depthTest: false, selectedFillMode: debugObject.currentFillMode);
+            RenderPrimitives(context, renderView, offsets: ref instanceOffsetsNoDepth, counts: ref primitivesToDrawNoDepth, depthTest: false, fillMode: debugObject.currentFillMode);
 
         }
 

--- a/DebugRendering/DebugRenderFeature.cs
+++ b/DebugRendering/DebugRenderFeature.cs
@@ -943,29 +943,6 @@ namespace DebugRendering
             if (RenderObjects.Count <= 0) return;
             DebugRenderObject debugObject = (DebugRenderObject)RenderObjects[0];
 
-            RenderStage FindTransparentRenderStage(RenderSystem renderSystem)
-            {
-                for (int i = 0; i < renderSystem.RenderStages.Count; ++i)
-                {
-                    var stage = renderSystem.RenderStages[i];
-                    if (stage.Name == "Transparent")
-                    {
-                        return stage;
-                    }
-                }
-                return null;
-            }
-
-            // we only want to render in the transparent stage, is there a nicer way to do this?
-            var transparentRenderStage = FindTransparentRenderStage(context.RenderContext.RenderSystem);
-            var transparentRenderStageIndex = transparentRenderStage?.Index;
-
-            // bail out if it's any other stage, this is crude but alas
-            if (renderViewStage.Index != transparentRenderStageIndex || ((RenderGroupMask)(1U << (int)RenderGroup) & renderView.CullingMask) == 0)
-            {
-                return;
-            }
-
             var commandList = context.CommandList;
 
             // update pipeline state, render with depth test first

--- a/DebugRendering/DebugRenderFeature.cs
+++ b/DebugRendering/DebugRenderFeature.cs
@@ -659,9 +659,8 @@ namespace DebugRendering
 
             // TODO: check if we actually have an object first next here
 
-            if (ObjectNodeReferences.Count <= 0) return;
-            ObjectNode objectNode = GetObjectNode(ObjectNodeReferences[0]);
-            DebugRenderObject debugObject = (DebugRenderObject)objectNode.RenderObject;
+            if (RenderObjects.Count <= 0) return;
+            DebugRenderObject debugObject = (DebugRenderObject)RenderObjects[0];
 
             /* everything except lines is included here, as lines just get accumulated into a buffer directly */
             int primitivesWithDepth = SumBasicPrimitives(ref debugObject.totalPrimitives);
@@ -937,13 +936,12 @@ namespace DebugRendering
 
         }
 
-        public override void Draw(RenderDrawContext context, RenderView renderView, RenderViewStage renderViewStage)
+        public override void Draw(RenderDrawContext context, RenderView renderView, RenderViewStage renderViewStage, int startIndex, int endIndex)
         {
 
             // TODO: check if we actually have one first next
-            if (ObjectNodeReferences.Count <= 0) return;
-            ObjectNode objectNode = GetObjectNode(ObjectNodeReferences[0]);
-            DebugRenderObject debugObject = (DebugRenderObject)objectNode.RenderObject;
+            if (RenderObjects.Count <= 0) return;
+            DebugRenderObject debugObject = (DebugRenderObject)RenderObjects[0];
 
             RenderStage FindTransparentRenderStage(RenderSystem renderSystem)
             {

--- a/DebugRendering/DebugSystem.cs
+++ b/DebugRendering/DebugSystem.cs
@@ -6,6 +6,7 @@ using System.Runtime.InteropServices;
 using Xenko.Core;
 using Xenko.Core.Collections;
 using Xenko.Core.Mathematics;
+using Xenko.Engine;
 using Xenko.Games;
 using Xenko.Graphics;
 using Xenko.Rendering;
@@ -194,8 +195,7 @@ namespace DebugRendering
         private readonly FastList<DebugRenderable> renderMessages = new FastList<DebugRenderable>();
         private readonly FastList<DebugRenderable> renderMessagesWithLifetime = new FastList<DebugRenderable>();
 
-        /* FIXME: this is set from outside atm, bit of a hack */
-        public DebugRenderFeature PrimitiveRenderer;
+        private DebugRenderFeature.DebugRenderObject primitiveRenderer;
 
         public RenderingMode RenderMode { get; set; } = RenderingMode.Wireframe;
 
@@ -325,14 +325,31 @@ namespace DebugRendering
         public override void Update(GameTime gameTime)
         {
 
-            PrimitiveRenderer.RenderGroup = RenderGroup;
+            // PrimitiveRenderer.RenderGroup = RenderGroup;
+            if (primitiveRenderer == null)
+            {
+                SceneSystem sceneSystem = Services.GetService<SceneSystem>();
+                if (sceneSystem != null)
+                {
+                    var groups = sceneSystem.SceneInstance.VisibilityGroups;
+                    if (groups.Count > 0)
+                    {
+                        var newDebugRenderObject = new DebugRenderFeature.DebugRenderObject();
+                        groups[0].RenderObjects.Add(newDebugRenderObject);
+                        primitiveRenderer = newDebugRenderObject;
+                    } else
+                    {
+                        return; // still no visibility group to use
+                    }
+                }
+            }
 
             switch (RenderMode) {
                 case RenderingMode.Wireframe:
-                    PrimitiveRenderer.SetFillMode(FillMode.Wireframe);
+                    primitiveRenderer.SetFillMode(FillMode.Wireframe);
                     break;
                 case RenderingMode.Solid:
-                    PrimitiveRenderer.SetFillMode(FillMode.Solid);
+                    primitiveRenderer.SetFillMode(FillMode.Solid);
                     break;
             }
 
@@ -368,52 +385,52 @@ namespace DebugRendering
                 switch (msg.Type)
                 {
                     case DebugRenderableType.Quad:
-                        PrimitiveRenderer.DrawQuad(ref msg.QuadData.Position, ref msg.QuadData.Size, ref msg.QuadData.Rotation, ref msg.QuadData.Color, depthTest: true);
+                        primitiveRenderer.DrawQuad(ref msg.QuadData.Position, ref msg.QuadData.Size, ref msg.QuadData.Rotation, ref msg.QuadData.Color, depthTest: true);
                         break;
                     case DebugRenderableType.QuadNoDepth:
-                        PrimitiveRenderer.DrawQuad(ref msg.QuadData.Position, ref msg.QuadData.Size, ref msg.QuadData.Rotation, ref msg.QuadData.Color, depthTest: false);
+                        primitiveRenderer.DrawQuad(ref msg.QuadData.Position, ref msg.QuadData.Size, ref msg.QuadData.Rotation, ref msg.QuadData.Color, depthTest: false);
                         break;
                     case DebugRenderableType.Circle:
-                        PrimitiveRenderer.DrawCircle(ref msg.CircleData.Position, msg.CircleData.Radius, ref msg.CircleData.Rotation, ref msg.CircleData.Color, depthTest: true);
+                        primitiveRenderer.DrawCircle(ref msg.CircleData.Position, msg.CircleData.Radius, ref msg.CircleData.Rotation, ref msg.CircleData.Color, depthTest: true);
                         break;
                     case DebugRenderableType.CircleNoDepth:
-                        PrimitiveRenderer.DrawCircle(ref msg.CircleData.Position, msg.CircleData.Radius, ref msg.CircleData.Rotation, ref msg.CircleData.Color, depthTest: false);
+                        primitiveRenderer.DrawCircle(ref msg.CircleData.Position, msg.CircleData.Radius, ref msg.CircleData.Rotation, ref msg.CircleData.Color, depthTest: false);
                         break;
                     case DebugRenderableType.Line:
-                        PrimitiveRenderer.DrawLine(ref msg.LineData.Start, ref msg.LineData.End, ref msg.LineData.Color, depthTest: true);
+                        primitiveRenderer.DrawLine(ref msg.LineData.Start, ref msg.LineData.End, ref msg.LineData.Color, depthTest: true);
                         break;
                     case DebugRenderableType.LineNoDepth:
-                        PrimitiveRenderer.DrawLine(ref msg.LineData.Start, ref msg.LineData.End, ref msg.LineData.Color, depthTest: false);
+                        primitiveRenderer.DrawLine(ref msg.LineData.Start, ref msg.LineData.End, ref msg.LineData.Color, depthTest: false);
                         break;
                     case DebugRenderableType.Cube:
-                        PrimitiveRenderer.DrawCube(ref msg.CubeData.Position, ref msg.CubeData.End, ref msg.CubeData.Rotation, ref msg.CubeData.Color, depthTest: true);
+                        primitiveRenderer.DrawCube(ref msg.CubeData.Position, ref msg.CubeData.End, ref msg.CubeData.Rotation, ref msg.CubeData.Color, depthTest: true);
                         break;
                     case DebugRenderableType.CubeNoDepth:
-                        PrimitiveRenderer.DrawCube(ref msg.CubeData.Position, ref msg.CubeData.End, ref msg.CubeData.Rotation, ref msg.CubeData.Color, depthTest: false);
+                        primitiveRenderer.DrawCube(ref msg.CubeData.Position, ref msg.CubeData.End, ref msg.CubeData.Rotation, ref msg.CubeData.Color, depthTest: false);
                         break;
                     case DebugRenderableType.Sphere:
-                        PrimitiveRenderer.DrawSphere(ref msg.SphereData.Position, msg.SphereData.Radius, ref msg.SphereData.Color, depthTest: true);
+                        primitiveRenderer.DrawSphere(ref msg.SphereData.Position, msg.SphereData.Radius, ref msg.SphereData.Color, depthTest: true);
                         break;
                     case DebugRenderableType.SphereNoDepth:
-                        PrimitiveRenderer.DrawSphere(ref msg.SphereData.Position, msg.SphereData.Radius, ref msg.SphereData.Color, depthTest: false);
+                        primitiveRenderer.DrawSphere(ref msg.SphereData.Position, msg.SphereData.Radius, ref msg.SphereData.Color, depthTest: false);
                         break;
                     case DebugRenderableType.Capsule:
-                        PrimitiveRenderer.DrawCapsule(ref msg.CapsuleData.Position, msg.CapsuleData.Height, msg.CapsuleData.Radius, ref msg.CapsuleData.Rotation, ref msg.CapsuleData.Color, depthTest: true);
+                        primitiveRenderer.DrawCapsule(ref msg.CapsuleData.Position, msg.CapsuleData.Height, msg.CapsuleData.Radius, ref msg.CapsuleData.Rotation, ref msg.CapsuleData.Color, depthTest: true);
                         break;
                     case DebugRenderableType.CapsuleNoDepth:
-                        PrimitiveRenderer.DrawCapsule(ref msg.CapsuleData.Position, msg.CapsuleData.Height, msg.CapsuleData.Radius, ref msg.CapsuleData.Rotation, ref msg.CapsuleData.Color, depthTest: false);
+                        primitiveRenderer.DrawCapsule(ref msg.CapsuleData.Position, msg.CapsuleData.Height, msg.CapsuleData.Radius, ref msg.CapsuleData.Rotation, ref msg.CapsuleData.Color, depthTest: false);
                         break;
                     case DebugRenderableType.Cylinder:
-                        PrimitiveRenderer.DrawCylinder(ref msg.CylinderData.Position, msg.CylinderData.Height, msg.CylinderData.Radius, ref msg.CylinderData.Rotation, ref msg.CylinderData.Color, depthTest: true);
+                        primitiveRenderer.DrawCylinder(ref msg.CylinderData.Position, msg.CylinderData.Height, msg.CylinderData.Radius, ref msg.CylinderData.Rotation, ref msg.CylinderData.Color, depthTest: true);
                         break;
                     case DebugRenderableType.CylinderNoDepth:
-                        PrimitiveRenderer.DrawCylinder(ref msg.CylinderData.Position, msg.CylinderData.Height, msg.CylinderData.Radius, ref msg.CylinderData.Rotation, ref msg.CylinderData.Color, depthTest: false);
+                        primitiveRenderer.DrawCylinder(ref msg.CylinderData.Position, msg.CylinderData.Height, msg.CylinderData.Radius, ref msg.CylinderData.Rotation, ref msg.CylinderData.Color, depthTest: false);
                         break;
                     case DebugRenderableType.Cone:
-                        PrimitiveRenderer.DrawCone(ref msg.ConeData.Position, msg.ConeData.Height, msg.ConeData.Radius, ref msg.ConeData.Rotation, ref msg.ConeData.Color, depthTest: true);
+                        primitiveRenderer.DrawCone(ref msg.ConeData.Position, msg.ConeData.Height, msg.ConeData.Radius, ref msg.ConeData.Rotation, ref msg.ConeData.Color, depthTest: true);
                         break;
                     case DebugRenderableType.ConeNoDepth:
-                        PrimitiveRenderer.DrawCone(ref msg.ConeData.Position, msg.ConeData.Height, msg.ConeData.Radius, ref msg.ConeData.Rotation, ref msg.ConeData.Color, depthTest: false);
+                        primitiveRenderer.DrawCone(ref msg.ConeData.Position, msg.ConeData.Height, msg.ConeData.Radius, ref msg.ConeData.Rotation, ref msg.ConeData.Color, depthTest: false);
                         break;
                 }
             }

--- a/DebugRendering/DebugTest.cs
+++ b/DebugRendering/DebugTest.cs
@@ -100,6 +100,19 @@ namespace DebugRendering
         public override void Start()
         {
 
+            RenderStage FindTransparentRenderStage(RenderSystem renderSystem)
+            {
+                for (int i = 0; i < renderSystem.RenderStages.Count; ++i)
+                {
+                    var stage = renderSystem.RenderStages[i];
+                    if (stage.Name == "Transparent")
+                    {
+                        return stage;
+                    }
+                }
+                return null;
+            }
+
             DebugDraw = new DebugSystem(Services);
             DebugDraw.PrimitiveColor = Color.Green;
             DebugDraw.MaxPrimitives = (currentNumPrimitives * 2) + 8;
@@ -107,10 +120,18 @@ namespace DebugRendering
 
             // FIXME
             var debugRenderFeatures = SceneSystem.GraphicsCompositor.RenderFeatures.OfType<DebugRenderFeature>();
+            var transparentRenderStage = FindTransparentRenderStage(SceneSystem.GraphicsCompositor.RenderSystem);
 
             if (!debugRenderFeatures.Any())
             {
-                var newDebugRenderFeature = new DebugRenderFeature();
+                var newDebugRenderFeature = new DebugRenderFeature() {
+                    RenderStageSelectors = {
+                        new SimpleGroupToRenderStageSelector
+                        {
+                            RenderStage = transparentRenderStage
+                        },
+                    }
+                };
                 SceneSystem.GraphicsCompositor.RenderFeatures.Add(newDebugRenderFeature);
             }
 

--- a/DebugRendering/DebugTest.cs
+++ b/DebugRendering/DebugTest.cs
@@ -112,11 +112,6 @@ namespace DebugRendering
             {
                 var newDebugRenderFeature = new DebugRenderFeature();
                 SceneSystem.GraphicsCompositor.RenderFeatures.Add(newDebugRenderFeature);
-                DebugDraw.PrimitiveRenderer = newDebugRenderFeature;
-            }
-            else
-            {
-                DebugDraw.PrimitiveRenderer = debugRenderFeatures.First();
             }
 
             // keep DebugText visible in release builds too


### PR DESCRIPTION
This is in order to not break things if we switch compositor at runtime for instance, so DebugSystem just creates one object it holds onto.